### PR TITLE
add husky, hooks for prettier and git submodules

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+git submodule update --init --recursive

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run prettier:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"@vitejs/plugin-react": "^4.0.4",
 				"classnames": "^2.3.2",
 				"esbuild-runner": "^2.2.2",
+				"husky": "^8.0.0",
 				"prettier": "^3.0.0",
 				"typescript": "^5.2.2",
 				"vite": "^4.4.9",
@@ -1951,6 +1952,21 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/husky": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+			"integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+			"dev": true,
+			"bin": {
+				"husky": "lib/bin.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
 			}
 		},
 		"node_modules/inflight": {
@@ -4528,6 +4544,12 @@
 				"agent-base": "6",
 				"debug": "4"
 			}
+		},
+		"husky": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+			"integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"@vitejs/plugin-react": "^4.0.4",
 		"classnames": "^2.3.2",
 		"esbuild-runner": "^2.2.2",
+		"husky": "^8.0.0",
 		"prettier": "^3.0.0",
 		"typescript": "^5.2.2",
 		"vite": "^4.4.9",
@@ -18,8 +19,9 @@
 	"description": "Tools for parsing Toaq Delta",
 	"main": "index.js",
 	"scripts": {
+		"prepare": "husky install && ./.husky/post-checkout",
 		"postinstall": "npm run codegen",
-		"prettier:check": "npx -p prettier prettier -c .",
+		"prettier:check": "npx -p prettier prettier -c --cache .",
 		"prettier:format": "npx -p prettier prettier -w .",
 		"cli": "npx esr src/index.ts",
 		"cli:debug": "node --inspect-brk -r esbuild-runner/register src/index.ts",


### PR DESCRIPTION
Doing the same thing as https://github.com/toaq/toadua/commit/d28e0ed1e8d635248639ea77bb4d0bd3f9270f36 did over here. In particular having submodules self-checkout is pretty neat (otherwise always such a pain point…).